### PR TITLE
Correct the releasever for RHELs

### DIFF
--- a/envoy_pkg/bintray_uploader_rpm.py
+++ b/envoy_pkg/bintray_uploader_rpm.py
@@ -38,6 +38,9 @@ DIST_RELEASE_PAIRS = [
     },
     {
         'dist': 'rhel',
+        # RHEL sets the yum var to `${version_number}${variant}`, while CentOS's defaults are just a version number.
+        # See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sec-using_yum_variables
+        # We can only assume the `Server` variant for our Envoy package.
         'releasever': '7Server'
     },
     {


### PR DESCRIPTION
Signed-off-by: Taiki Ono <taiki@tetrate.io>

RHEL sets the yum var to `${version_number}${variant}`, while CentOS's defaults are just a version number . See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sec-using_yum_variables We can only assume the "Server" variant for our Envoy package.

The error of `yum install -y getenvoy-envoy`:

```
failure: repodata/repomd.xml from tetrate-getenvoy-stable: [Errno 256] No more mirrors to try.
https://tetrate.bintray.com/getenvoy-rpm/rhel/7Server/x86_64/stable/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
```