### PR TITLE
build clang-toolchain in centos

### DIFF
--- a/clang-toolchain/Dockerfile
+++ b/clang-toolchain/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:7 AS builder
+
+COPY ./install_build_deps.sh /root
+RUN /root/install_build_deps.sh
+
+COPY ./build_clang_llvm.sh /home/build
+CMD ["/home/build/build_clang_llvm.sh"]

--- a/clang-toolchain/build_clang_llvm.sh
+++ b/clang-toolchain/build_clang_llvm.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+curl -sSL https://raw.githubusercontent.com/llvm/llvm-project/llvmorg-8.0.1/llvm/utils/release/test-release.sh | sed 's,http://llvm.org,https://llvm.org,' > /home/build/test-release.sh
+chmod +x /home/build/test-release.sh
+
+mkdir -p ${BUILD_DIR}
+chown build:build ${BUILD_DIR}
+
+sudo -u build scl enable devtoolset-7 \
+  "/home/build/test-release.sh -release 8.0.1 -final -triple x86_64-linux-centos7 -configure-flags '-DCOMPILER_RT_BUILD_LIBFUZZER=off' -build-dir ${BUILD_DIR}"

--- a/clang-toolchain/cloudbuild.yaml
+++ b/clang-toolchain/cloudbuild.yaml
@@ -1,0 +1,35 @@
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- id: deps
+  name: gcr.io/cloud-builders/docker
+  dir: clang-toolchain
+  args: ['build', '-t', 'centos-llvm-build', '.']
+
+- id: clang-toolchain
+  name: centos-llvm-build
+  env:
+  - "BUILD_DIR=/workspace/llvm-build"
+
+artifacts:
+  objects:
+    location: "gs://getenvoy-package/clang-toolchain/$COMMIT_SHA/"
+    paths:
+    - "/workspace/llvm-build/final/logs/*"
+    - "/workspace/llvm-build/final/clang+llvm-8.0.1-x86_64-linux-centos7.tar.xz"
+options:
+  machineType: N1_HIGHCPU_32
+  logging: GCS_ONLY
+timeout: 5h

--- a/clang-toolchain/install_build_deps.sh
+++ b/clang-toolchain/install_build_deps.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+yum install -y centos-release-scl epel-release
+yum update -y
+yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ wget unzip which make cmake3 patch subversion ncurses-devel zlib-devel python-virtualenv chrpath file perl-Data-Dumper tcl python2-psutil sudo
+
+ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+useradd build


### PR DESCRIPTION
reliable tested toolchain for single glibc binary build. put this in a sparate directory / cloud build because it takes long time to build

already run on GCB which passes all supported tests
https://storage.cloud.google.com/getenvoy-package/clang-toolchain/a7802955c6a79782b221c69cb24e35a1fbb9a96d/testing.8.0.1-final.log 
