### PR TITLE
add linux-glibc bazel image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ jobs:
           gcloud config set gcloudignore/enabled false
           gcloud builds submit --config=cloudbuild/build_image.yaml . \
               --project ${GOOGLE_PROJECT_ID} --substitutions _GIT_SHA=${CIRCLE_SHA1}
+          gcloud builds submit --config=cloudbuild/test_image.yaml . \
+              --project ${GOOGLE_PROJECT_ID} --substitutions _GIT_SHA=${CIRCLE_SHA1}
 
   release_mac:
     <<: *mac

--- a/cloudbuild/build_image.yaml
+++ b/cloudbuild/build_image.yaml
@@ -69,11 +69,29 @@ steps:
   env:
   - 'ENVOY_DIST=ubuntu-xenial'
 
+- name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
+  waitFor: ['rbe-linux-glibc']
+  dir: ../envoy_pkg
+  entrypoint: '/envoy_pkg/package_envoy.py'
+  args: ['--test_package', '--test_distroless']
+  env:
+  - 'ENVOY_DIST=linux-glibc'
+
+- name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
+  waitFor: ['rbe-linux-glibc']
+  dir: ../envoy_pkg
+  entrypoint: '/envoy_pkg/package_envoy.py'
+  args: ['--build_deb_package', '--build_rpm_package', '--build-distroless-docker']
+  env:
+  - 'ENVOY_DIST=linux-glibc'
+
+
 images:
   - gcr.io/getenvoy-package/build-alpine:$_GIT_SHA
   - gcr.io/getenvoy-package/build-centos:$_GIT_SHA
   - gcr.io/getenvoy-package/build-ubuntu-xenial:$_GIT_SHA
   - gcr.io/getenvoy-package/rbe-linux-glibc:$_GIT_SHA
+  - gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
 options:
   workerPool: 'getenvoy-package/envoy-build'
   env:

--- a/cloudbuild/build_image.yaml
+++ b/cloudbuild/build_image.yaml
@@ -45,47 +45,6 @@ steps:
   name: make
   args: ['linux-glibc']
 
-- name: gcr.io/getenvoy-package/build-alpine:$_GIT_SHA
-  waitFor: ['build-alpine']
-  dir: ../envoy_pkg
-  entrypoint: '/envoy_pkg/package_envoy.py'
-  args: ['--test_package']
-  env:
-  - 'ENVOY_DIST=alpine'
-
-- name: gcr.io/getenvoy-package/build-centos:$_GIT_SHA
-  waitFor: ['build-centos']
-  dir: ../envoy_pkg
-  entrypoint: '/envoy_pkg/package_envoy.py'
-  args: ['--test_package']
-  env:
-  - 'ENVOY_DIST=centos'
-
-- name: gcr.io/getenvoy-package/build-ubuntu-xenial:$_GIT_SHA
-  waitFor: ['build-ubuntu-xenial']
-  dir: ../envoy_pkg
-  entrypoint: '/envoy_pkg/package_envoy.py'
-  args: ['--test_package', '--test_distroless']
-  env:
-  - 'ENVOY_DIST=ubuntu-xenial'
-
-- name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
-  waitFor: ['rbe-linux-glibc']
-  dir: ../envoy_pkg
-  entrypoint: '/envoy_pkg/package_envoy.py'
-  args: ['--test_package', '--test_distroless']
-  env:
-  - 'ENVOY_DIST=linux-glibc-docker'
-
-- name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
-  waitFor: ['rbe-linux-glibc']
-  dir: ../envoy_pkg
-  entrypoint: '/envoy_pkg/package_envoy.py'
-  args: ['--build_deb_package', '--build_distroless_docker']
-  env:
-  - 'ENVOY_DIST=linux-glibc-docker'
-
-
 images:
   - gcr.io/getenvoy-package/build-alpine:$_GIT_SHA
   - gcr.io/getenvoy-package/build-centos:$_GIT_SHA

--- a/cloudbuild/build_image.yaml
+++ b/cloudbuild/build_image.yaml
@@ -75,7 +75,7 @@ steps:
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package', '--test_distroless']
   env:
-  - 'ENVOY_DIST=linux-glibc'
+  - 'ENVOY_DIST=linux-glibc-docker'
 
 - name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
   waitFor: ['rbe-linux-glibc']
@@ -83,7 +83,7 @@ steps:
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--build_deb_package', '--build_distroless_docker']
   env:
-  - 'ENVOY_DIST=linux-glibc'
+  - 'ENVOY_DIST=linux-glibc-docker'
 
 
 images:

--- a/cloudbuild/build_image.yaml
+++ b/cloudbuild/build_image.yaml
@@ -81,7 +81,7 @@ steps:
   waitFor: ['rbe-linux-glibc']
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
-  args: ['--build_deb_package', '--build_rpm_package', '--build-distroless-docker']
+  args: ['--build_deb_package', '--build_distroless_docker']
   env:
   - 'ENVOY_DIST=linux-glibc'
 

--- a/cloudbuild/test_image.yaml
+++ b/cloudbuild/test_image.yaml
@@ -14,7 +14,7 @@
 
 steps:
 - name: gcr.io/getenvoy-package/build-alpine:$_GIT_SHA
-  waitFor: ['build-alpine']
+  waitFor: []
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package']
@@ -22,7 +22,7 @@ steps:
   - 'ENVOY_DIST=alpine'
 
 - name: gcr.io/getenvoy-package/build-centos:$_GIT_SHA
-  waitFor: ['build-centos']
+  waitFor: []
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package']
@@ -30,7 +30,7 @@ steps:
   - 'ENVOY_DIST=centos'
 
 - name: gcr.io/getenvoy-package/build-ubuntu-xenial:$_GIT_SHA
-  waitFor: ['build-ubuntu-xenial']
+  waitFor: []
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package', '--test_distroless']
@@ -38,20 +38,20 @@ steps:
   - 'ENVOY_DIST=ubuntu-xenial'
 
 - name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
-  waitFor: ['rbe-linux-glibc']
+  waitFor: []
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package', '--test_distroless']
   env:
-  - 'ENVOY_DIST=linux-glibc-docker'
+  - 'ENVOY_DIST=linux-glibc'
 
 - name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
-  waitFor: ['rbe-linux-glibc']
+  waitFor: []
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--build_deb_package', '--build_distroless_docker']
   env:
-  - 'ENVOY_DIST=linux-glibc-docker'
+  - 'ENVOY_DIST=linux-glibc'
 
 options:
   workerPool: 'getenvoy-package/envoy-build'

--- a/cloudbuild/test_image.yaml
+++ b/cloudbuild/test_image.yaml
@@ -1,0 +1,60 @@
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: gcr.io/getenvoy-package/build-alpine:$_GIT_SHA
+  waitFor: ['build-alpine']
+  dir: ../envoy_pkg
+  entrypoint: '/envoy_pkg/package_envoy.py'
+  args: ['--test_package']
+  env:
+  - 'ENVOY_DIST=alpine'
+
+- name: gcr.io/getenvoy-package/build-centos:$_GIT_SHA
+  waitFor: ['build-centos']
+  dir: ../envoy_pkg
+  entrypoint: '/envoy_pkg/package_envoy.py'
+  args: ['--test_package']
+  env:
+  - 'ENVOY_DIST=centos'
+
+- name: gcr.io/getenvoy-package/build-ubuntu-xenial:$_GIT_SHA
+  waitFor: ['build-ubuntu-xenial']
+  dir: ../envoy_pkg
+  entrypoint: '/envoy_pkg/package_envoy.py'
+  args: ['--test_package', '--test_distroless']
+  env:
+  - 'ENVOY_DIST=ubuntu-xenial'
+
+- name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
+  waitFor: ['rbe-linux-glibc']
+  dir: ../envoy_pkg
+  entrypoint: '/envoy_pkg/package_envoy.py'
+  args: ['--test_package', '--test_distroless']
+  env:
+  - 'ENVOY_DIST=linux-glibc-docker'
+
+- name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
+  waitFor: ['rbe-linux-glibc']
+  dir: ../envoy_pkg
+  entrypoint: '/envoy_pkg/package_envoy.py'
+  args: ['--build_deb_package', '--build_distroless_docker']
+  env:
+  - 'ENVOY_DIST=linux-glibc-docker'
+
+options:
+  workerPool: 'getenvoy-package/envoy-build'
+  env:
+  - 'TEST_TMPDIR=/tmp'
+timeout: 3600s

--- a/cloudbuild/test_image.yaml
+++ b/cloudbuild/test_image.yaml
@@ -14,7 +14,7 @@
 
 steps:
 - name: gcr.io/getenvoy-package/build-alpine:$_GIT_SHA
-  waitFor: []
+  waitFor: ['-']
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package']
@@ -22,7 +22,7 @@ steps:
   - 'ENVOY_DIST=alpine'
 
 - name: gcr.io/getenvoy-package/build-centos:$_GIT_SHA
-  waitFor: []
+  waitFor: ['-']
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package']
@@ -30,7 +30,7 @@ steps:
   - 'ENVOY_DIST=centos'
 
 - name: gcr.io/getenvoy-package/build-ubuntu-xenial:$_GIT_SHA
-  waitFor: []
+  waitFor: ['-']
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package', '--test_distroless']
@@ -38,7 +38,7 @@ steps:
   - 'ENVOY_DIST=ubuntu-xenial'
 
 - name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
-  waitFor: []
+  waitFor: ['-']
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--test_package', '--test_distroless']
@@ -46,7 +46,7 @@ steps:
   - 'ENVOY_DIST=linux-glibc'
 
 - name: gcr.io/getenvoy-package/bazel-linux-glibc:$_GIT_SHA
-  waitFor: []
+  waitFor: ['-']
   dir: ../envoy_pkg
   entrypoint: '/envoy_pkg/package_envoy.py'
   args: ['--build_deb_package', '--build_distroless_docker']

--- a/envoy_pkg/.bazelrc
+++ b/envoy_pkg/.bazelrc
@@ -71,5 +71,15 @@ build:linux-glibc --remote_instance_name=projects/getenvoy-package/instances/def
 build:linux-glibc --jobs=80
 build:linux-glibc --experimental_remote_download_outputs=all
 
+build:linux-glibc-docker --experimental_docker_image=gcr.io/getenvoy-package/rbe-linux-glibc@sha256:17a9702b9c29f6e244c415b67fc43c43ec432a9e602b412e5efc9b9e25f2bff7
+build:linux-glibc-docker --config=linux-glibc-toolchain
+build:linux-glibc-docker --spawn_strategy=docker
+build:linux-glibc-docker --strategy=Javac=docker
+build:linux-glibc-docker --strategy=Closure=docker
+build:linux-glibc-docker --strategy=Genrule=docker
+build:linux-glibc-docker --define=EXECUTOR=remote
+build:linux-glibc-docker --experimental_docker_verbose
+build:linux-glibc-docker --experimental_enable_docker_sandbox
+
 # This is no-op but if this doesn't exist bazel will error with non-exist config
 build:darwin --announce_rc

--- a/envoy_pkg/.bazelrc
+++ b/envoy_pkg/.bazelrc
@@ -45,5 +45,31 @@ build:centos --define force_libcpp=enabled
 build:ubuntu-xenial --action_env=PATH=/usr/lib/llvm-8/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 build:ubuntu-xenial --linkopt=-fuse-ld=lld
 
+build:linux-glibc-toolchain --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
+build:linux-glibc-toolchain --javabase=@bazel_tools//tools/jdk:remote_jdk11
+build:linux-glibc-toolchain --host_platform=@envoy_pkg//bazel:rbe_linux_glibc_platform
+build:linux-glibc-toolchain --platforms=@envoy_pkg//bazel:rbe_linux_glibc_platform
+build:linux-glibc-toolchain --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:linux-glibc-toolchain --crosstool_top=@rbe_linux_glibc//cc:toolchain
+build:linux-glibc-toolchain --extra_toolchains=@rbe_linux_glibc//config:cc-toolchain
+build:linux-glibc-toolchain --action_env=CC=clang --action_env=CXX=clang++
+
+build:remote --spawn_strategy=remote,sandboxed,local
+build:remote --strategy=Javac=remote,sandboxed,local
+build:remote --strategy=Closure=remote,sandboxed,local
+build:remote --strategy=Genrule=remote,sandboxed,local
+build:remote --remote_timeout=3600
+build:remote --auth_enabled=true
+build:remote --experimental_inmemory_jdeps_files
+build:remote --experimental_inmemory_dotd_files
+
+build:linux-glibc --config=linux-glibc-toolchain
+build:linux-glibc --config=remote
+build:linux-glibc --remote_cache=grpcs://remotebuildexecution.googleapis.com
+build:linux-glibc --remote_executor=grpcs://remotebuildexecution.googleapis.com
+build:linux-glibc --remote_instance_name=projects/getenvoy-package/instances/default_instance
+build:linux-glibc --jobs=80
+build:linux-glibc --experimental_remote_download_outputs=all
+
 # This is no-op but if this doesn't exist bazel will error with non-exist config
 build:darwin --announce_rc

--- a/envoy_pkg/bazel/bazel_toolchains.bzl
+++ b/envoy_pkg/bazel/bazel_toolchains.bzl
@@ -1,0 +1,15 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def bazel_toolchains_repositories():
+    if "bazel_toolchains" in native.existing_rules():
+        return
+
+    http_archive(
+        name = "bazel_toolchains",
+        sha256 = "d8c2f20deb2f6143bac792d210db1a4872102d81529fe0ea3476c1696addd7ff",
+        strip_prefix = "bazel-toolchains-0.28.3",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.28.3.tar.gz",
+            "https://github.com/bazelbuild/bazel-toolchains/archive/0.28.3.tar.gz",
+        ],
+    )

--- a/envoy_pkg/bazel/rbe_envs.bzl
+++ b/envoy_pkg/bazel/rbe_envs.bzl
@@ -1,0 +1,12 @@
+def rbe_envs():
+    return {
+        "BAZEL_COMPILER": "clang",
+        "BAZEL_LINKLIBS": "-l%:libc++.a:-l%:libc++abi.a",
+        "BAZEL_LINKOPTS": "-lm:-static-libgcc:-pthread:-fuse-ld=lld",
+        "BAZEL_USE_LLVM_NATIVE_COVERAGE": "1",
+        "GCOV": "llvm-profdata",
+        "CC": "clang",
+        "CXX": "clang++",
+        "BAZEL_CXXOPTS": "-stdlib=libc++",
+        "CXXFLAGS": "-stdlib=libc++",
+    }

--- a/envoy_pkg/getenvoy.WORKSPACE
+++ b/envoy_pkg/getenvoy.WORKSPACE
@@ -50,7 +50,24 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
     name = "distroless_base",
-    digest = "sha256:e37cf3289c1332c5123cbf419a1657c8dad0811f2f8572433b668e13747718f8", # 2019-07-11
+    digest = "sha256:e37cf3289c1332c5123cbf419a1657c8dad0811f2f8572433b668e13747718f8", # 2019-07-25
     registry = "gcr.io",
     repository = "distroless/base",
+)
+
+load("//bazel:bazel_toolchains.bzl", "bazel_toolchains_repositories")
+
+bazel_toolchains_repositories()
+
+load("//bazel:rbe_envs.bzl", "rbe_envs")
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+
+rbe_autoconfig(
+    name = "rbe_linux_glibc",
+    create_java_configs = False,
+    env = rbe_envs(),
+    digest = "{RBE_IMAGE_DIGEST}",
+    registry = "gcr.io",
+    repository = "getenvoy-package/rbe-linux-glibc",
+    use_checked_in_confs = "False",
 )

--- a/envoy_pkg/getenvoy.WORKSPACE
+++ b/envoy_pkg/getenvoy.WORKSPACE
@@ -66,7 +66,7 @@ rbe_autoconfig(
     name = "rbe_linux_glibc",
     create_java_configs = False,
     env = rbe_envs(),
-    digest = "{RBE_IMAGE_DIGEST}",
+    tag = "{RBE_IMAGE_TAG}",
     registry = "gcr.io",
     repository = "getenvoy-package/rbe-linux-glibc",
     use_checked_in_confs = "False",

--- a/envoy_pkg/package_envoy.py
+++ b/envoy_pkg/package_envoy.py
@@ -166,7 +166,8 @@ def setUpWorkspace(variant):
             workspace_content = workspace.read()
         if "{ENVOY_SRCDIR}" in workspace_content:
             workspace_content = workspace_content.replace(
-                '{ENVOY_SRCDIR}', 'envoy')
+                '{ENVOY_SRCDIR}', 'envoy').replace('"envoy_filter_example"',
+                                                   '"envoy_pkg"')
         elif '"/source"' in workspace_content:
             workspace_content = workspace_content.replace(
                 '"/source"', '"envoy"')
@@ -186,8 +187,13 @@ def setUpWorkspace(variant):
             raise "Failed to setup workspace"
 
     with open('WORKSPACE', 'a+') as workspace:
-        with open('WORKSPACE.containers') as append:
-            workspace.write(append.read())
+        with open('getenvoy.WORKSPACE') as append:
+            workspace.write(append.read().replace(
+                '{RBE_IMAGE_DIGEST}',
+                os.environ.get(
+                    'RBE_IMAGE_DIGEST',
+                    'sha256:17a9702b9c29f6e244c415b67fc43c43ec432a9e602b412e5efc9b9e25f2bff7'
+                )))
 
     writeSourceInfo()
 

--- a/envoy_pkg/package_envoy.py
+++ b/envoy_pkg/package_envoy.py
@@ -190,10 +190,8 @@ def setUpWorkspace(variant):
         with open('getenvoy.WORKSPACE') as append:
             workspace.write(append.read().replace(
                 '{RBE_IMAGE_TAG}',
-                os.environ.get(
-                    'RBE_IMAGE_TAG',
-                    '26527a7d8f6c340c8efcdb0fc70dfea778d2a561'
-                )))
+                os.environ.get('RBE_IMAGE_TAG',
+                               '26527a7d8f6c340c8efcdb0fc70dfea778d2a561')))
 
     writeSourceInfo()
 

--- a/envoy_pkg/package_envoy.py
+++ b/envoy_pkg/package_envoy.py
@@ -189,10 +189,10 @@ def setUpWorkspace(variant):
     with open('WORKSPACE', 'a+') as workspace:
         with open('getenvoy.WORKSPACE') as append:
             workspace.write(append.read().replace(
-                '{RBE_IMAGE_DIGEST}',
+                '{RBE_IMAGE_TAG}',
                 os.environ.get(
-                    'RBE_IMAGE_DIGEST',
-                    'sha256:17a9702b9c29f6e244c415b67fc43c43ec432a9e602b412e5efc9b9e25f2bff7'
+                    'RBE_IMAGE_TAG',
+                    '26527a7d8f6c340c8efcdb0fc70dfea778d2a561'
                 )))
 
     writeSourceInfo()

--- a/linux-glibc/Dockerfile.bazel
+++ b/linux-glibc/Dockerfile.bazel
@@ -19,8 +19,8 @@ COPY build_container/getenvoy_linux_glibc_bazel.sh /build_container/getenvoy_lin
 WORKDIR /build_container
 RUN ./getenvoy_linux_glibc_bazel.sh
 
-ARG rbe_image_digest
-ENV RBE_IMAGE_DIGEST=$rbe_image_digest
+ARG rbe_image_tag
+ENV RBE_IMAGE_TAG=$rbe_image_tag
 
 COPY envoy_pkg /envoy_pkg
 WORKDIR /envoy_pkg

--- a/linux-glibc/Dockerfile.bazel
+++ b/linux-glibc/Dockerfile.bazel
@@ -12,22 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-exports_files([
-    "envoy_test_wrapper",
-])
+FROM ubuntu:xenial
 
-platform(
-    name = "rbe_linux_glibc_platform",
-    parents = ["@rbe_linux_glibc//config:platform"],
-    remote_execution_properties = """
-        {PARENT_REMOTE_EXECUTION_PROPERTIES}
-        properties: {
-          name: "dockerAddCapabilities"
-          value: "SYS_PTRACE,NET_RAW,NET_ADMIN"
-        }
-        properties: {
-          name: "dockerNetwork"
-          value: "standard"
-        }
-        """,
-)
+COPY build_container/getenvoy_linux_glibc_bazel.sh /build_container/getenvoy_linux_glibc_bazel.sh
+
+WORKDIR /build_container
+RUN ./getenvoy_linux_glibc_bazel.sh
+
+ARG rbe_image_digest
+ENV RBE_IMAGE_DIGEST=$rbe_image_digest
+
+COPY envoy_pkg /envoy_pkg
+WORKDIR /envoy_pkg

--- a/linux-glibc/Dockerfile.rbe
+++ b/linux-glibc/Dockerfile.rbe
@@ -14,7 +14,7 @@
 
 FROM centos:7
 
-COPY build_container/ /build_container
+COPY build_container/getenvoy_linux_glibc_rbe.sh /build_container/getenvoy_linux_glibc_rbe.sh
 
 WORKDIR /build_container
-RUN ./getenvoy_linux_glibc.sh
+RUN ./getenvoy_linux_glibc_rbe.sh

--- a/linux-glibc/Makefile
+++ b/linux-glibc/Makefile
@@ -23,7 +23,8 @@ BAZEL_TAG = $(BAZEL_IMAGE):$(SHA)
 $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-bazel.tar: $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar
 	@cat $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar | \
 	    docker build - -t $(BAZEL_TAG) -f Dockerfile.bazel \
-		--build-arg rbe_image_digest=`docker inspect --format='{{.RepoDigests}}' gcr.io/getenvoy-package/rbe-linux-glibc:330ea7dab7c926530ce9454034f46bfa8a72ad57 | grep -oE 'sha256:[0-9a-f]+'`
+	    --build-arg rbe_image_digest=`docker inspect --format='{{.RepoDigests}}' gcr.io/getenvoy-package/rbe-linux-glibc:330ea7dab7c926530ce9454034f46bfa8a72ad57 | grep -oE 'sha256:[0-9a-f]+'`
+	@docker inspect --format='{{.RepoDigests}}' gcr.io/getenvoy-package/rbe-linux-glibc:330ea7dab7c926530ce9454034f46bfa8a72ad57 | grep -oE 'sha256:[0-9a-f]+'
 	@docker save $(BAZEL_TAG) -o $@
 
 $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar: build_container/getenvoy_linux_glibc_rbe.sh Dockerfile.rbe

--- a/linux-glibc/Makefile
+++ b/linux-glibc/Makefile
@@ -24,7 +24,7 @@ $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-bazel.tar: $(OUTPUT_DIR)/$(DISTRO)/b
 	@docker inspect --format='{{.Id}}' $(RBE_TAG)
 	@cat $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar | \
 	    docker build - -t $(BAZEL_TAG) -f Dockerfile.bazel \
-	    --build-arg rbe_image_digest=`docker inspect --format='{{.Id}}' $(RBE_TAG)`
+	    --build-arg rbe_image_tag=$(SHA)
 	@docker save $(BAZEL_TAG) -o $@
 
 $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar: build_container/getenvoy_linux_glibc_rbe.sh Dockerfile.rbe

--- a/linux-glibc/Makefile
+++ b/linux-glibc/Makefile
@@ -24,7 +24,7 @@ $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-bazel.tar: $(OUTPUT_DIR)/$(DISTRO)/b
 	@cat $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar | \
 	    docker build - -t $(BAZEL_TAG) -f Dockerfile.bazel \
 	    --build-arg rbe_image_digest=`docker inspect --format='{{.RepoDigests}}' $(RBE_TAG) | grep -oE 'sha256:[0-9a-f]+'`
-	@docker inspect --format='{{.RepoDigests}}' $(RBE_TAG) | grep -oE 'sha256:[0-9a-f]+'
+	docker inspect --format='{{.RepoDigests}}' $(RBE_TAG) | grep -oE 'sha256:[0-9a-f]+'
 	@docker save $(BAZEL_TAG) -o $@
 
 $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar: build_container/getenvoy_linux_glibc_rbe.sh Dockerfile.rbe

--- a/linux-glibc/Makefile
+++ b/linux-glibc/Makefile
@@ -23,8 +23,8 @@ BAZEL_TAG = $(BAZEL_IMAGE):$(SHA)
 $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-bazel.tar: $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar
 	@cat $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar | \
 	    docker build - -t $(BAZEL_TAG) -f Dockerfile.bazel \
-	    --build-arg rbe_image_digest=`docker inspect --format='{{.RepoDigests}}' gcr.io/getenvoy-package/rbe-linux-glibc:330ea7dab7c926530ce9454034f46bfa8a72ad57 | grep -oE 'sha256:[0-9a-f]+'`
-	@docker inspect --format='{{.RepoDigests}}' gcr.io/getenvoy-package/rbe-linux-glibc:330ea7dab7c926530ce9454034f46bfa8a72ad57 | grep -oE 'sha256:[0-9a-f]+'
+	    --build-arg rbe_image_digest=`docker inspect --format='{{.RepoDigests}}' $(RBE_TAG) | grep -oE 'sha256:[0-9a-f]+'`
+	@docker inspect --format='{{.RepoDigests}}' $(RBE_TAG) | grep -oE 'sha256:[0-9a-f]+'
 	@docker save $(BAZEL_TAG) -o $@
 
 $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar: build_container/getenvoy_linux_glibc_rbe.sh Dockerfile.rbe

--- a/linux-glibc/Makefile
+++ b/linux-glibc/Makefile
@@ -15,24 +15,43 @@
 OUTPUT_DIR ?= ../build-image
 DISTRO = linux-glibc
 SHA = $(shell git rev-parse HEAD)
-IMAGE =  gcr.io/getenvoy-package/rbe-$(DISTRO)
-TAG = $(IMAGE):$(SHA)
+RBE_IMAGE = gcr.io/getenvoy-package/rbe-$(DISTRO)
+RBE_TAG = $(RBE_IMAGE):$(SHA)
+BAZEL_IMAGE = gcr.io/getenvoy-package/bazel-$(DISTRO)
+BAZEL_TAG = $(BAZEL_IMAGE):$(SHA)
 
-$(OUTPUT_DIR)/$(DISTRO)/envoy-package-build.tar: build_container Dockerfile.rbe
-	mkdir -p $(OUTPUT_DIR)/$(DISTRO)
-	docker build . -t $(TAG) -f Dockerfile.rbe
-	docker save $(TAG) -o $@
+$(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-bazel.tar: $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar
+	@cat $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar | \
+	    docker build - -t $(BAZEL_TAG) -f Dockerfile.bazel \
+		--build-arg rbe_image_digest=`docker inspect --format='{{.RepoDigests}}' gcr.io/getenvoy-package/rbe-linux-glibc:330ea7dab7c926530ce9454034f46bfa8a72ad57 | grep -oE 'sha256:[0-9a-f]+'`
+	@docker save $(BAZEL_TAG) -o $@
+
+$(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar: build_container/getenvoy_linux_glibc_rbe.sh Dockerfile.rbe
+	@mkdir -p $(OUTPUT_DIR)/$(DISTRO)
+	@docker build . -t $(RBE_TAG) -f Dockerfile.rbe
+	@docker save $(RBE_TAG) -o $@
+
+$(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar: $(OUTPUT_DIR)/common-context.tar build_container/getenvoy_linux_glibc_bazel.sh Dockerfile.bazel
+	@mkdir -p $(OUTPUT_DIR)/$(DISTRO)
+	@cp $(OUTPUT_DIR)/common-context.tar $@
+	@tar -r build_container/getenvoy_linux_glibc_bazel.sh -f $@
+	@tar -r Dockerfile.bazel -f $@
 
 .PHONY: push
-push: $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build.tar
-	@docker load -i $<
-	@docker push $(TAG)
+push: $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-bazel.tar
+	@docker load -i $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar 
+	@docker push $(RBE_TAG)
+	@docker load -i $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-bazel.tar 
+	@docker push $(BAZEL_TAG)
 
 .PHONY: release
 release:
-	@docker pull $(TAG)
-	@docker tag $(TAG) $(IMAGE):latest
-	@docker push $(IMAGE):latest
+	@docker pull $(RBE_TAG)
+	@docker tag $(RBE_TAG) $(RBE_IMAGE):latest
+	@docker push $(RBE_IMAGE):latest
+	@docker pull $(BAZEL_TAG)
+	@docker tag $(BAZEL_TAG) $(BAZEL_IMAGE):latest
+	@docker push $(BAZEL_IMAGE):latest
 
 .PHONY: clean
 clean:

--- a/linux-glibc/Makefile
+++ b/linux-glibc/Makefile
@@ -21,10 +21,10 @@ BAZEL_IMAGE = gcr.io/getenvoy-package/bazel-$(DISTRO)
 BAZEL_TAG = $(BAZEL_IMAGE):$(SHA)
 
 $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-bazel.tar: $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar
+	@docker inspect --format='{{.Id}}' $(RBE_TAG)
 	@cat $(OUTPUT_DIR)/$(DISTRO)/bazel-docker-context.tar | \
 	    docker build - -t $(BAZEL_TAG) -f Dockerfile.bazel \
-	    --build-arg rbe_image_digest=`docker inspect --format='{{.RepoDigests}}' $(RBE_TAG) | grep -oE 'sha256:[0-9a-f]+'`
-	docker inspect --format='{{.RepoDigests}}' $(RBE_TAG) | grep -oE 'sha256:[0-9a-f]+'
+	    --build-arg rbe_image_digest=`docker inspect --format='{{.Id}}' $(RBE_TAG)`
 	@docker save $(BAZEL_TAG) -o $@
 
 $(OUTPUT_DIR)/$(DISTRO)/envoy-package-build-rbe.tar: build_container/getenvoy_linux_glibc_rbe.sh Dockerfile.rbe

--- a/linux-glibc/build_container/getenvoy_linux_glibc_bazel.sh
+++ b/linux-glibc/build_container/getenvoy_linux_glibc_bazel.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2019 Tetrate
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get -y update
+
+apt-get install -y --no-install-recommends curl wget make git python python-pip python-setuptools python3 python3-pip \
+  unzip bc libtool ninja-build automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client \
+  software-properties-common apt-transport-https ca-certificates
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+apt-get update && apt-get -y install docker-ce docker-ce-cli containerd.io
+
+apt-get clean
+
+# bazelisk
+VERSION=0.0.8
+SHA256=5fced4fec06bf24beb631837fa9497b6698f34041463d9188610dfa7b91f4f8d
+curl --location --output /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v${VERSION}/bazelisk-linux-amd64 \
+  && echo "$SHA256  /usr/local/bin/bazel" | sha256sum --check \
+  && chmod +x /usr/local/bin/bazel

--- a/linux-glibc/build_container/getenvoy_linux_glibc_rbe.sh
+++ b/linux-glibc/build_container/getenvoy_linux_glibc_rbe.sh
@@ -25,7 +25,7 @@ ln -s /usr/bin/cmake3 /usr/bin/cmake
 ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 curl -sSL http://storage.googleapis.com/getenvoy-package/clang-toolchain/edc07275ac4d48bd50d43cce1a042d12111dbc72/clang+llvm-8.0.1-x86_64-linux-centos7.tar.xz | \
-  tar Jxv --strip-components=1 -C /usr/local
+  tar Jx --strip-components=1 -C /usr/local
 
 # For FIPS (Clang 6.0.1 to detect GCC)
 mkdir -p /usr/lib/gcc/x86_64-redhat-linux


### PR DESCRIPTION
For RBE, the toolchain image is CentOS 7 based so the binary output is CentOS compatible, while invoking bazel from Ubuntu 16.04.

With this structure, test can be performed on both OS by specifying --strategy=TestRunner={remote,local}.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>