### PR TITLE
allow build all linux from same pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,8 @@ jobs:
                                           gcr.io/getenvoy-package/build-centos:latest --quiet
           gcloud container images add-tag gcr.io/getenvoy-package/build-ubuntu-xenial:$CIRCLE_SHA1 \
                                           gcr.io/getenvoy-package/build-ubuntu-xenial:latest --quiet
+          gcloud container images add-tag gcr.io/getenvoy-package/bazel-linux-glibc:$CIRCLE_SHA1 \
+                                          gcr.io/getenvoy-package/build-linux-glibc:latest --quiet
 
   test_envoy_build_mac:
     <<: *mac

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ CI built images are published to [`gcr.io/getenvoy-package`](https://gcr.io/gete
 To build the GetEnvoy package with the build image, run:
 
 ```
-docker run -v ${OUTPUT_DIR}:/tmp/packaged gcr.io/getenvoy-package/build-<DISTRIBUTION>:<GIT_SHA> ./package_envoy.py --dist <DISTRIBUTION>
+docker run -v ${OUTPUT_DIR}:/tmp/getenvoy-package gcr.io/getenvoy-package/build-<DISTRIBUTION>:<GIT_SHA> ./package_envoy.py --dist <DISTRIBUTION>
 ```
 
 Then the tar package will be copied to where `OUTPUT_DIR` points to. The GetEnvoy package is versioned with upstream git SHA and the build repo SHA. i

--- a/envoy_pkg/.bazelrc
+++ b/envoy_pkg/.bazelrc
@@ -19,6 +19,8 @@ build --strip=never --copt=-ggdb3
 build --action_env=BAZEL_COMPILER=clang
 build --action_env=CC=clang
 build --action_env=CXX=clang++
+build --incompatible_strict_action_env
+build --test_output=errors
 
 build:release --compilation_mode=opt
 

--- a/envoy_pkg/mac/setup.sh
+++ b/envoy_pkg/mac/setup.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e -o pipefail
+set -e
 
-BINARY="test/version_info"
+brew tap bazelbuild/tap
+brew install bazelbuild/tap/bazelisk cmake coreutils go libtool ninja wget
 
-${BINARY} --version | grep -E '^[0-9a-f]{40}/[0-9]+\.[0-9]+\.[0-9]+(-dev)?/clean-getenvoy-[0-9a-f]{7}-[^/]+/(DEBUG|RELEASE)/(.*)$'

--- a/envoy_pkg/rpm/getenvoy-envoy.spec.template
+++ b/envoy_pkg/rpm/getenvoy-envoy.spec.template
@@ -17,6 +17,4 @@ tar -xvf {rpm-data.tar} -C %{buildroot}
 
 %files
 /usr/bin/envoy
-/opt/getenvoy/bin/envoy
-/opt/getenvoy/lib/libc++.so.1
-/opt/getenvoy/lib/libc++abi.so.1
+/opt/getenvoy/**

--- a/envoy_pkg/rpm/getenvoy-istio-proxy.spec.template
+++ b/envoy_pkg/rpm/getenvoy-istio-proxy.spec.template
@@ -17,6 +17,4 @@ tar -xvf {rpm-data.tar} -C %{buildroot}
 
 %files
 /usr/bin/envoy
-/opt/getenvoy/bin/envoy
-/opt/getenvoy/lib/libc++.so.1
-/opt/getenvoy/lib/libc++abi.so.1
+/opt/getenvoy/**


### PR DESCRIPTION
For linux-glibc pipleine which deprecates current ubuntu-xenial / centos pipeline.

- add variant to version info so we can have istio-proxy in the version info
- split mac setup in independent script (for istio-proxy)
- store (tar,rpm,deb,distroless) artifact in a fixed place

Signed-off-by: Lizan Zhou <lizan@tetrate.io>