### PR TITLE
Upload artifacts for CentOS 8

### DIFF
--- a/envoy_pkg/bintray_uploader_rpm.py
+++ b/envoy_pkg/bintray_uploader_rpm.py
@@ -39,6 +39,10 @@ DIST_RELEASE_PAIRS = [
         'releasever': '7'
     },
     {
+        'dist': 'centos',
+        'releasever': '8'
+    },
+    {
         'dist': 'rhel',
         # RHEL sets the yum var to `${version_number}${variant}`, while CentOS's defaults are just a version number.
         # See https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sec-using_yum_variables


### PR DESCRIPTION
Signed-off-by: Taiki Ono <taiki@tetrate.io>

Fixes https://github.com/tetratelabs/getenvoy-package/issues/48

I've checked the binary is working on RHEL8 correctly. With some investigations, I can't find a quick way to test CentOS 8 RC, so I'll check it after CentOS 8 release.