### PR TITLE
Stop using HTTPError.fp.read()

### DIFF
--- a/envoy_pkg/bintray_uploader.py
+++ b/envoy_pkg/bintray_uploader.py
@@ -52,13 +52,11 @@ def uploadToBintray(args, override=False):
         except urllib.error.HTTPError as e:
             if e.code == 409:
                 logging.info('{} is already exists'.format(args.filename))
-                logging.info(e.fp.read())
                 # We already have uploaded the binnary, so don't raise errors
             else:
                 logging.error(
                     'Failed to upload to bintray: response code {}'.format(
                         e.code))
-                logging.error(e.fp.read())
                 raise
 
 

--- a/envoy_pkg/bintray_uploader_deb.py
+++ b/envoy_pkg/bintray_uploader_deb.py
@@ -110,13 +110,11 @@ def uploadToBintrayDeb(args, variant):
         except urllib.error.HTTPError as e:
             if e.code == 409:
                 logging.info('{} is already exists'.format(args.filename))
-                logging.info(e.fp.read())
                 # We already have uploaded the package, so don't raise errors
             else:
                 logging.error(
                     'Failed to upload to bintray: response code {}'.format(
                         e.code))
-                logging.error(e.fp.read())
                 raise
 
 

--- a/envoy_pkg/bintray_uploader_rpm.py
+++ b/envoy_pkg/bintray_uploader_rpm.py
@@ -110,13 +110,11 @@ def uploadToBintrayRpm(args, variant):
             except urllib.error.HTTPError as e:
                 if e.code == 409:
                     logging.info('{} is already exists'.format(args.filename))
-                    logging.info(e.fp.read())
                     # We already have uploaded the package, so don't raise errors
                 else:
                     logging.error(
                         'Failed to upload to bintray: response code {}'.format(
                             e.code))
-                    logging.error(e.fp.read())
                     raise
 
 


### PR DESCRIPTION
This has a bug in Python 3.5. https://bugs.python.org/issue26499
So just stop using it as a work-around.

Signed-off-by: Taiki Ono <taiki@tetrate.io>

When a binary has been already uploaded to Bintray, Bintray responds with 409 and the code failed to handle the HTTP error. The failure is caused by the bug above, so just skip as a work-around. Another option is upgrading the python version, but skipping is more cost-effective here, I think, as the line is not much valuable relatively.

The actual error is in the internal build "9af0d350-5bd2-495f-895b-6b99c73cfb67".