### PR TITLE
Update macos version to update ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ version: 2.0
 references:
   mac: &mac
     macos:
-      xcode: '10.1.0'
+      xcode: '11.2.1'
     working_directory: ~/envoy-package
 
 jobs:


### PR DESCRIPTION
We need ruby 2.6 above for the latest Homebrew.

Signed-off-by: Taiki Ono <taiki@tetrate.io>

CI error https://app.circleci.com/jobs/github/tetratelabs/getenvoy-package/1072:

```
/usr/local/Homebrew/Library/Homebrew/brew.rb:10:in `<main>': Homebrew must be run under Ruby 2.6! You're running 2.3.7. (RuntimeError)
Traceback (most recent call last):
  File "/usr/local/opt/envoy_pkg/package_envoy.py", line 284, in <module>
    main()
  File "/usr/local/opt/envoy_pkg/package_envoy.py", line 267, in main
    subprocess.check_call(['mac/setup.sh'])
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/subprocess.py", line 328, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['mac/setup.sh']' returned non-zero exit status 1.
```

Xcode version specification and installed software list:

- https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
- https://circle-macos-docs.s3.amazonaws.com/image-manifest/v1532/index.html