### PR TITLE
mac: Guard brew upgrade against python3 upgrade

### DIFF
--- a/envoy_pkg/mac/setup.sh
+++ b/envoy_pkg/mac/setup.sh
@@ -17,6 +17,9 @@
 set -ex
 
 brew update
-brew upgrade
+# It is possible that the upgrade of python is failed. However, the required archive are already
+# extracted. We need to link it up as "python3" since most of the scripts in this repository
+# require /usr/bin/env python3 to be correctly resolved.
+brew upgrade || ln -s /usr/local/bin/python /usr/local/bin/python3 || echo "symbolic link for python3 exists"
 brew tap bazelbuild/tap
 brew install bazelbuild/tap/bazelisk cmake coreutils go libtool ninja wget


### PR DESCRIPTION
This patch guards the failing brew upgrade for python3. The approach is by linking the installed python binary (which is already version 3, after the upgrade process) to python3 under the `/usr/local/bin` directory. 


An example of error logs when upgrading python (via Homebrew) is as follows:

```
==> Pouring python-3.7.6.mojave.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink Frameworks/Python.framework/Headers
Target /usr/local/Frameworks/Python.framework/Headers
is a symlink belonging to python@2. You can unlink it:
  brew unlink python@2

To force the link and overwrite all conflicting files:
  brew link --overwrite python

To list all files that would be deleted:
  brew link --overwrite --dry-run python

Possible conflicting files are:
/usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@2/2.7.16_1/Frameworks/Python.framework/Headers
/usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@2/2.7.16_1/Frameworks/Python.framework/Python
/usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@2/2.7.16_1/Frameworks/Python.framework/Resources
/usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@2/2.7.16_1/Frameworks/Python.framework/Versions/Current
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install
==> Caveats
Python has been installed as
  /usr/local/bin/python3

Unversioned symlinks `python`, `python-config`, `pip` etc. pointing to
`python3`, `python3-config`, `pip3` etc., respectively, have been installed into
  /usr/local/opt/python/libexec/bin

If you need Homebrew's Python 2.7 run
  brew install python@2

You can install Python packages with
  pip3 install <package>
They will install into the site-package directory
  /usr/local/lib/python3.7/site-packages

See: https://docs.brew.sh/Homebrew-and-Python
```

The `echo $?` after this command is `!=0`.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>