### PR TITLE
mac: Guard brew upgrade against python3 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ jobs:
     <<: *mac
     environment:
       ENVOY_DIST: darwin
+      _JAVA_OPTIONS: -Xmx1g
     steps:
       - checkout
       - run: git status # to fix CircleCI spurious git error

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ version: 2.0
 references:
   mac: &mac
     macos:
-      xcode: '11.2.1'
+      xcode: '11.3.0'
     working_directory: ~/envoy-package
 
 jobs:

--- a/api/manifest.pb.go
+++ b/api/manifest.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Tetrate
+// Copyright 2020 Tetrate
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/envoy_pkg/.bazelrc
+++ b/envoy_pkg/.bazelrc
@@ -15,7 +15,7 @@
 import %workspace%/envoy/.bazelrc
 
 # GetEnvoy startup options. Overrides the default one.
-startup --host_jvm_args=-Xmx1g
+startup --host_jvm_args=-Xmx512m
 
 # GetEnvoy options
 build --strip=never --copt=-ggdb3

--- a/envoy_pkg/.bazelrc
+++ b/envoy_pkg/.bazelrc
@@ -14,6 +14,9 @@
 #
 import %workspace%/envoy/.bazelrc
 
+# GetEnvoy startup options. Overrides the default one.
+startup --host_jvm_args=-Xmx1g
+
 # GetEnvoy options
 build --strip=never --copt=-ggdb3
 build --action_env=BAZEL_COMPILER=clang

--- a/envoy_pkg/.bazelrc
+++ b/envoy_pkg/.bazelrc
@@ -90,3 +90,6 @@ build:linux-glibc-docker --experimental_enable_docker_sandbox
 
 # This is no-op but if this doesn't exist bazel will error with non-exist config
 build:darwin --announce_rc
+build:darwin --discard_analysis_cache
+build:darwin --notrack_incremental_state
+build:darwin --nokeep_state_after_build

--- a/envoy_pkg/mac/setup.sh
+++ b/envoy_pkg/mac/setup.sh
@@ -17,6 +17,9 @@
 set -ex
 
 brew update
-brew upgrade
+# It is possible that the upgrade of python is failed. However, the required archive are already
+# extracted. We need to link it up as "python3" since most of the scripts in this repository
+# require /usr/bin/env python3 to be correctly resolved.
+brew upgrade || ln -s /usr/local/bin/python /usr/local/bin/python3 || echo "symbolic link for python3 exists"
 brew tap bazelbuild/tap
 brew install bazelbuild/tap/bazelisk cmake coreutils go libtool ninja wget

--- a/envoy_pkg/package_envoy.py
+++ b/envoy_pkg/package_envoy.py
@@ -44,7 +44,7 @@ def runBazel(command, targets, startup_options={}, options={}):
             argv.extend(['--{}={}'.format(k, i) for i in v])
     argv.extend(targets)
     logging.debug(" ".join(argv))
-    subprocess.check_call(argv)
+    subprocess.check_output(argv, stderr=subprocess.STDOUT)
 
 
 def bazelOptions(args):

--- a/envoy_pkg/package_envoy.py
+++ b/envoy_pkg/package_envoy.py
@@ -44,7 +44,7 @@ def runBazel(command, targets, startup_options={}, options={}):
             argv.extend(['--{}={}'.format(k, i) for i in v])
     argv.extend(targets)
     logging.debug(" ".join(argv))
-    subprocess.check_output(argv, stderr=subprocess.STDOUT)
+    subprocess.check_call(argv)
 
 
 def bazelOptions(args):


### PR DESCRIPTION
This patch guards the failing brew upgrade for python3. The approach is by linking the installed python binary (which is already version 3, after the upgrade process) to python3 under the `/usr/local/bin` directory. 

An example of error logs when upgrading python (via Homebrew) is as follows:

```
==> Pouring python-3.7.6.mojave.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink Frameworks/Python.framework/Headers
Target /usr/local/Frameworks/Python.framework/Headers
is a symlink belonging to python@2. You can unlink it:
  brew unlink python@2

To force the link and overwrite all conflicting files:
  brew link --overwrite python

To list all files that would be deleted:
  brew link --overwrite --dry-run python

Possible conflicting files are:
/usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@2/2.7.16_1/Frameworks/Python.framework/Headers
/usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@2/2.7.16_1/Frameworks/Python.framework/Python
/usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@2/2.7.16_1/Frameworks/Python.framework/Resources
/usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@2/2.7.16_1/Frameworks/Python.framework/Versions/Current
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install
==> /usr/local/Cellar/python/3.7.6/bin/python3 -s setup.py --no-user-cfg install
==> Caveats
Python has been installed as
  /usr/local/bin/python3

Unversioned symlinks `python`, `python-config`, `pip` etc. pointing to
`python3`, `python3-config`, `pip3` etc., respectively, have been installed into
  /usr/local/opt/python/libexec/bin

If you need Homebrew's Python 2.7 run
  brew install python@2

You can install Python packages with
  pip3 install <package>
They will install into the site-package directory
  /usr/local/lib/python3.7/site-packages

See: https://docs.brew.sh/Homebrew-and-Python
```

The `echo $?` after this command is `!=0`.

Signed-off-by: Dhi Aurrahman <dio@tetrate.io>