### PR TITLE
guard against uploading things that already exist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ version: 2.0
 references:
   mac: &mac
     macos:
-      xcode: '11.2.1'
+      xcode: '11.3.1'
     working_directory: ~/envoy-package
 
 jobs:

--- a/api/manifest.pb.go
+++ b/api/manifest.pb.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Tetrate
+// Copyright 2020 Tetrate
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/envoy_pkg/package_envoy.py
+++ b/envoy_pkg/package_envoy.py
@@ -137,26 +137,50 @@ def storeArtifacts(args, workspace_info):
         subprocess.check_call(['xz', '-f', docker_image_tar])
 
 
+def bailIfPackagesExist(args, workspace_info):
+    subprocess.check_call([
+        './bintray_uploader.py', '--version',
+        version.debVersion(workspace_info), '--check_nonexisting',
+        os.path.join(args.artifacts_directory,
+                     version.tarFileName(workspace_info))
+    ])
+    subprocess.check_call([
+        './bintray_uploader.py', '--version',
+        version.debVersion(workspace_info), '--check_nonexisting',
+        os.path.join(args.artifacts_directory,
+                     version.tarFileName(workspace_info, symbol=True))
+    ])
+
+
 def uploadArtifacts(args, workspace_info):
     directory = args.artifacts_directory
     subprocess.check_call([
-        './bintray_uploader.py', '--version',
+        './bintray_uploader.py',
+        '--version',
         version.debVersion(workspace_info),
-        os.path.join(directory, version.tarFileName(workspace_info))
+        os.path.join(directory, version.tarFileName(workspace_info)),
+        '--override',
+        str(args.override),
     ])
     subprocess.check_call([
-        './bintray_uploader.py', '--version',
+        './bintray_uploader.py',
+        '--version',
         version.debVersion(workspace_info),
         os.path.join(directory, version.tarFileName(workspace_info,
-                                                    symbol=True))
+                                                    symbol=True)),
+        '--override',
+        str(args.override),
     ])
     if args.build_deb_package:
         subprocess.check_call([
-            './bintray_uploader_deb.py', '--variant',
-            workspace_info['variant'], '--deb_version',
-            version.debVersion(workspace_info), '--release_level',
+            './bintray_uploader_deb.py',
+            '--variant',
+            workspace_info['variant'],
+            '--deb_version',
+            version.debVersion(workspace_info),
+            '--release_level',
             args.release_level,
-            os.path.join(directory, version.debFileName(workspace_info))
+            os.path.join(directory, version.debFileName(workspace_info)),
         ])
     if args.build_rpm_package:
         subprocess.check_call([
@@ -222,6 +246,7 @@ def main():
     parser.add_argument('--nosetup', action='store_true')
     parser.add_argument('--nocleanup', action='store_true')
     parser.add_argument('--upload', action='store_true')
+    parser.add_argument('--override', action='store_true', default=False)
     parser.add_argument('--test_distroless', action='store_true')
     parser.add_argument('--test_package', action='store_true')
     parser.add_argument('--test_envoy',
@@ -270,6 +295,8 @@ def main():
     else:
         if args.test_envoy:
             testEnvoy(args)
+        if args.upload and not args.override:
+            bailIfPackagesExist(args, workspace_info)
         buildPackages(args)
         if not args.artifacts_directory:
             tempdir = tempfile.TemporaryDirectory()

--- a/envoy_pkg/package_envoy.py
+++ b/envoy_pkg/package_envoy.py
@@ -293,10 +293,10 @@ def main():
     if args.test_package:
         testPackage(args)
     else:
-        if args.test_envoy:
-            testEnvoy(args)
         if args.upload and not args.override:
             bailIfPackagesExist(args, workspace_info)
+        if args.test_envoy:
+            testEnvoy(args)
         buildPackages(args)
         if not args.artifacts_directory:
             tempdir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
this patch will prevent uploading a package that already exists
unless `--override` is specified, which will now properly trigger
an upload to be overriden.

Signed-off-by: Cynthia <cynthia@tetrate.io>