### PR TITLE
Fix nightly envoy build linux glibc errors

### DIFF
--- a/envoy_pkg/bintray_uploader.py
+++ b/envoy_pkg/bintray_uploader.py
@@ -37,7 +37,8 @@ def checkBintray(args):
         request = urllib.request.Request(bintray_url, headers=headers)
         request.get_method = lambda: 'GET'
         response = urllib.request.urlopen(request)
-        files = json.loads(response.read())
+        str_response = response.readall().decode('utf-8')
+        files = json.loads(str_response)
 
         for existing_file in files:
             if "name" not in existing_file:

--- a/envoy_pkg/getenvoy.WORKSPACE
+++ b/envoy_pkg/getenvoy.WORKSPACE
@@ -16,9 +16,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
-    strip_prefix = "rules_docker-0.14.4",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
+    sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
+    strip_prefix = "rules_docker-0.15.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz"],
 )
 
 load(
@@ -34,7 +34,7 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
 
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", pip_deps = "io_bazel_rules_docker_pip_deps")
 
 pip_deps()
 


### PR DESCRIPTION
Fixes this error seen in nightly builds
https://app.circleci.com/pipelines/github/tetratelabs/getenvoy-ci/1200/workflows/a94383a0-08b6-471c-bf7c-fc269349d164/jobs/4952
```
Step #1:   File "./bintray_uploader.py", line 129, in <module>
Step #1:     main()
Step #1:   File "./bintray_uploader.py", line 123, in main
Step #1:     sys.exit(checkBintray(args))
Step #1:   File "./bintray_uploader.py", line 40, in checkBintray
Step #1:     files = json.loads(response.read())
Step #1:   File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
Step #1:     s.__class__.__name__))
Step #1: TypeError: the JSON object must be str, not 'bytes'
```
python3 uses bytes natively, so explicitly convert to string so
the json package can consume it properly

Signed-off-by: Arko Dasgupta <arko@tetrate.io>