### PR TITLE
Fix GetEnvoy CI

### DIFF
--- a/envoy_pkg/bintray_uploader.py
+++ b/envoy_pkg/bintray_uploader.py
@@ -37,7 +37,8 @@ def checkBintray(args):
         request = urllib.request.Request(bintray_url, headers=headers)
         request.get_method = lambda: 'GET'
         response = urllib.request.urlopen(request)
-        files = json.loads(response.read())
+        str_response = response.readall().decode('utf-8')
+        files = json.loads(str_response)
 
         for existing_file in files:
             if "name" not in existing_file:

--- a/envoy_pkg/getenvoy.WORKSPACE
+++ b/envoy_pkg/getenvoy.WORKSPACE
@@ -16,9 +16,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
-    strip_prefix = "rules_docker-0.14.4",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
+    sha256 = "1698624e878b0607052ae6131aa216d45ebb63871ec497f26c67455b34119c80",
+    strip_prefix = "rules_docker-0.15.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.15.0/rules_docker-v0.15.0.tar.gz"],
 )
 
 load(
@@ -34,7 +34,7 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
 
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", pip_deps = "io_bazel_rules_docker_pip_deps")
 
 pip_deps()
 


### PR DESCRIPTION
1. Fix bazel pip deps issue

Seeing this new error related to bazel

```
Step #0: ERROR: Traceback (most recent call last):
Step #0:        File "/envoy_pkg/WORKSPACE", line 61, column 15, in <toplevel>
Step #0:                container_deps()
Step #0:        File "/tmp/_bazel_root/70a134053c2bce265097714ee92378c8/external/io_bazel_rules_docker/repositories/deps.bzl", line 35, column 12, in deps
Step #0:                py_deps()
Step #0:        File "/tmp/_bazel_root/70a134053c2bce265097714ee92378c8/external/io_bazel_rules_docker/repositories/py_repositories.bzl", line 36, column 19, in py_deps
Step #0:                pip_import(
Step #0:        File "/tmp/_bazel_root/70a134053c2bce265097714ee92378c8/external/rules_python/python/pip.bzl", line 64, column 9, in pip_import
Step #0:                fail("=" * 79 + """\n
Step #0: Error in fail: ===============================================================================
Step #0:
Step #0:     pip_import has been replaced with pip_install, please see the rules_python 0.1 release notes.
Step #0:     To continue using it, you can load from "@rules_python//python/legacy_pip_import:pip.bzl"
```

Updated the `bazelbuild/rules_docker` version and used the
updated/renamed rule for `pip_deps`

2. Fixes this error seen in nightly builds
https://app.circleci.com/pipelines/github/tetratelabs/getenvoy-ci/1200/workflows/a94383a0-08b6-471c-bf7c-fc269349d164/jobs/4952
```
Step #1:   File "./bintray_uploader.py", line 129, in <module>
Step #1:     main()
Step #1:   File "./bintray_uploader.py", line 123, in main
Step #1:     sys.exit(checkBintray(args))
Step #1:   File "./bintray_uploader.py", line 40, in checkBintray
Step #1:     files = json.loads(response.read())
Step #1:   File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
Step #1:     s.__class__.__name__))
Step #1: TypeError: the JSON object must be str, not 'bytes'
```
python3 uses bytes natively, so explicitly convert to string so
the json package can consume it properly

Signed-off-by: Arko Dasgupta <arko@tetrate.io>