### PR TITLE
Add the target architecture field to the manifest.proto

### DIFF
--- a/api/manifest.proto
+++ b/api/manifest.proto
@@ -65,6 +65,13 @@ message Build {
       LINUX_GLIBC = 3;
    }
 
+   enum Architecture {
+      UNKNOWN = 0;
+      X86_64 = 1;
+      ARM64 = 2;
+   }
+
    Platform platform = 1;
    string download_location_url = 2;
+   Architecture architecture = 3;
 }


### PR DESCRIPTION
Add the target architecture of envoy builds to the `manifest.proto`. These changes are related to getenvoy arm support https://github.com/tetratelabs/getenvoy/issues/109.