### PR TITLE
fix Mac upload

### DIFF
--- a/envoy_pkg/build_context.py
+++ b/envoy_pkg/build_context.py
@@ -30,6 +30,7 @@ from cloudsmith_uploader import upload_to_cloudsmith_raw as upload_to_cloudsmith
 
 # upload the Mac build tar
 def upload_build_context(args: Any) -> None:
+    # this also re-uploads the `envoy-package-build-SHA.tar` file as `envoy-package-build-latest.tar`
     package_name = "envoy-package-build-{}.tar".format(args.version)
     shutil.copy(
         os.path.expanduser(

--- a/envoy_pkg/cloudsmith_uploader.py
+++ b/envoy_pkg/cloudsmith_uploader.py
@@ -57,13 +57,18 @@ def check_cloudsmith(args: Any) -> int:
 
 
 def upload_to_cloudsmith_raw(args, override=False) -> None:
-    cmd = "cloudsmith push raw --api-key {auth_token} {org}/{repo} {filename} --version {version}".format(
+    # Cloudsmith treats `latest` version as a special case
+    # Basically, if 2 files with the same filename but different version tags (except for `latest`, e.g. a SHA) are
+    # uploaded, CS auto-assigns the `latest` tag to the file that was uploaded later
+    # So, don't do the explicit `latest` tagging
+    cmd = "cloudsmith push raw --api-key {auth_token} {org}/{repo} {filename}".format(
         auth_token=args.cloudsmith_auth,
         org=args.cloudsmith_org,
         repo=args.cloudsmith_repo,
         filename=args.filename,
-        version=args.version,
     )
+    if args.version != "latest":
+        cmd += " --version {}".format(args.version)
     if override:
         cmd += " --republish"
     else:


### PR DESCRIPTION
- the version is already encoded in the name
- cloudsmith treats `latest` as a SPECIAL case, basically
auto-generating it from the upload timestamp/order, so specifying it
explicitly breaks stuff.

Signed-off-by: Denis Zaitcev <denis@tetrate.io>